### PR TITLE
[Needle] Fix wrong id in the RigidMapping in the scene

### DIFF
--- a/scenes/NeedleInsertion.py
+++ b/scenes/NeedleInsertion.py
@@ -101,7 +101,7 @@ def createScene(root):
     needleTipCollision = needle.addChild("tipCollision")
     needleTipCollision.addObject("MechanicalObject",name="mstate",position=[g_needleLength+g_needleBaseOffset[0], g_needleBaseOffset[1], g_needleBaseOffset[2]],template="Vec3d",)
     needleTipCollision.addObject("PointGeometry",name="geom",mstate="@mstate")
-    needleTipCollision.addObject("RigidMapping",globalToLocalCoords=True)
+    needleTipCollision.addObject("RigidMapping",globalToLocalCoords=True,index=g_needleNumberOfElems)
 
 
     needleVisual = needle.addChild("visual")


### PR DESCRIPTION
The mapping couples the mechanical state of the main needle node and that of the tip collision node. The provided index was wrong causing the forces applied on the tip to be mapped to the base of the needle. Fixes #14 

This caused the data variable "lambda" to take values at the wrong index (see figs below) 

<img width="896" height="540" alt="25-07-15-TipMappingBefore" src="https://github.com/user-attachments/assets/4708a91e-a22a-4fed-8413-a251e2092eca" />

<img width="921" height="600" alt="25-07-15-TipMappingAfter" src="https://github.com/user-attachments/assets/e8cce076-313c-47dc-9f50-1f1f534ae157" />
