### PR TITLE
[Needle] Use the MechanicalState of the needle tip node to get the impulse and initiate puncture

### DIFF
--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -90,13 +90,18 @@ public:
         auto& output = *d_output.beginEdit();
         auto& outputInside = *d_outputInside.beginEdit();
 
-        const sofa::component::statecontainer::MechanicalObject<defaulttype::RigidTypes>* mstate
-            = l_from->getContext()->get<sofa::component::statecontainer::MechanicalObject<defaulttype::RigidTypes>>();
+        const sofa::component::statecontainer::MechanicalObject<defaulttype::Vec3Types>* mstate
+            = l_from->getContext()->get<sofa::component::statecontainer::MechanicalObject<defaulttype::Vec3Types>>();
+        if (mstate->getSize() > 1)
+        {
+            msg_warning() << "Requested MechanicalObject, corresponding to the tip of the needle in the InsertionAlgorithm, has a size greater than 1. "
+                        << "The algorithm is designed to work with a single point. Only the first element will be used.";
+        }
         if (m_constraintSolver)
         {
-            defaulttype::RigidTypes::Vec3 lambda = 
-                m_constraintSolver->getLambda()[mstate].read()->getValue()[mstate->getSize()-1].getVCenter();
-            if (lambda.norm() > d_punctureThreshold.getValue())
+            defaulttype::Vec3Types::VecCoord lambda =
+                m_constraintSolver->getLambda()[mstate].read()->getValue();
+            if (lambda[0].norm() > d_punctureThreshold.getValue())
             {
                 for (const auto& itOutputPair : output) {
                     m_proximities.push_back(itOutputPair.second->copy());


### PR DESCRIPTION
The InsertionAlgorithm uses the MechanicalState holding all the DOFs of the needle model to get the value of lambda (the impulse) from the constraint solver and compare it with the puncture threshold. By convention, it is assumed that the DOF at the tip of the needle is the last element in this MechanicalState. 

With this PR, the algorithm uses the mstate that corresponds to the needle tip node instead. This is more direct and appropriate.

> [!NOTE] 
> It is assumed that the MechanicalObject in the needle tip node is of type Vec3 and that it is of size = 1.

Closes #13 

<img width="1893" height="898" alt="25-07-15-TipLambda" src="https://github.com/user-attachments/assets/3de8c5a1-9c12-4467-80d0-59966c23f2b6" />
