### PR TITLE
[Needle][algorithm] Extension of the insertion algorithm for proximity detection inside the volume

### DIFF
--- a/scenes/NeedleInsertion.py
+++ b/scenes/NeedleInsertion.py
@@ -181,7 +181,7 @@ def createScene(root):
         destGeom="@Volume/collision/geom_tri", 
         destVol="@Volume/geom_tetra", 
         punctureThreshold=0.1, 
-        slideDistance=0.012
+        slideDistance=0.015
         #projective=True
     )
     root.addObject("DistanceFilter",algo="@InsertionAlgo",distance=0.01)

--- a/scenes/NeedleInsertion.py
+++ b/scenes/NeedleInsertion.py
@@ -179,9 +179,10 @@ def createScene(root):
     root.addObject("InsertionAlgorithm", name="InsertionAlgo", 
         fromGeom="@Needle/tipCollision/geom", 
         destGeom="@Volume/collision/geom_tri", 
+        fromVol="@Needle/bodyCollision/geom", 
         destVol="@Volume/geom_tetra", 
         punctureThreshold=0.1, 
-        slideDistance=0.015
+        slideDistance=0.005
         #projective=True
     )
     root.addObject("DistanceFilter",algo="@InsertionAlgo",distance=0.01)

--- a/scenes/NeedleInsertion.py
+++ b/scenes/NeedleInsertion.py
@@ -176,7 +176,14 @@ def createScene(root):
     volumeVisuWire.addObject("IdentityMapping")
 
 
-    root.addObject("InsertionAlgorithm", name="InsertionAlgo", fromGeom="@Needle/tipCollision/geom", destGeom="@Volume/collision/geom_tri", destVol="@Volume/geom_tetra", punctureThreshold=0.1)
+    root.addObject("InsertionAlgorithm", name="InsertionAlgo", 
+        fromGeom="@Needle/tipCollision/geom", 
+        destGeom="@Volume/collision/geom_tri", 
+        destVol="@Volume/geom_tetra", 
+        punctureThreshold=0.1, 
+        slideDistance=0.012
+        #projective=True
+    )
     root.addObject("DistanceFilter",algo="@InsertionAlgo",distance=0.01)
     root.addObject("SecondDirection",name="punctureDirection",handler="@Volume/collision/SurfaceTriangles")
     root.addObject("ConstraintUnilateral",input="@InsertionAlgo.output",directions="@punctureDirection",draw_scale="0.001")#, mu="0.001")

--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -158,13 +158,17 @@ public:
                     m_needlePts.push_back(m_needlePts.back());
 
                     auto itfromVol = l_fromVol->begin(l_fromVol->getSize() - 1 - m_couplingPts.size());
-                    auto createProximityOp_vol = Operations::CreateCenterProximity::Operation::get(itfromVol->getTypeInfo());
+                    //auto createProximityOp_vol = Operations::CreateCenterProximity::Operation::get(itfromVol->getTypeInfo());
+
+                    auto findClosestProxOp_needle = Operations::FindClosestProximity::Operation::get(l_fromVol);
+                    auto projectOp_needle = Operations::Project::Operation::get(l_fromVol);
 
                     for(int i = 0 ; i < m_needlePts.size() - 1; i++)
                     {
-                        auto pfromVol = createProximityOp_vol(itfromVol->element());
+                        //auto pfromVol = createProximityOp_vol(itfromVol->element());
+                        auto pfromVol = findClosestProxOp_needle(m_couplingPts[i], l_fromVol.get(), projectOp_needle, getFilterFunc());
                         if (d_projective.getValue()) {
-                            auto pfromVolProj = projectFromOp_vol(pdestVol->getPosition(), itfromVol->element()).prox;
+                            auto pfromVolProj = projectFromOp_vol(m_couplingPts[i]->getPosition(), itfromVol->element()).prox;
                             if (pfromVolProj == nullptr) continue;
                             pfromVolProj->normalize();
                             m_needlePts[i] = pfromVolProj;

--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -158,25 +158,14 @@ public:
                     m_needlePts.push_back(m_needlePts.back());
 
                     auto itfromVol = l_fromVol->begin(l_fromVol->getSize() - 1 - m_couplingPts.size());
-                    //auto createProximityOp_vol = Operations::CreateCenterProximity::Operation::get(itfromVol->getTypeInfo());
 
                     auto findClosestProxOp_needle = Operations::FindClosestProximity::Operation::get(l_fromVol);
                     auto projectOp_needle = Operations::Project::Operation::get(l_fromVol);
 
                     for(int i = 0 ; i < m_needlePts.size() - 1; i++)
                     {
-                        //auto pfromVol = createProximityOp_vol(itfromVol->element());
                         auto pfromVol = findClosestProxOp_needle(m_couplingPts[i], l_fromVol.get(), projectOp_needle, getFilterFunc());
-                        if (d_projective.getValue()) {
-                            auto pfromVolProj = projectFromOp_vol(m_couplingPts[i]->getPosition(), itfromVol->element()).prox;
-                            if (pfromVolProj == nullptr) continue;
-                            pfromVolProj->normalize();
-                            m_needlePts[i] = pfromVolProj;
-                        }
-                        else {
-                            m_needlePts[i] = pfromVol;
-                        }
-                        itfromVol++;
+                        m_needlePts[i] = pfromVol;
                     }
 
                     for(int i = 0 ; i < m_needlePts.size(); i++)

--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -31,7 +31,6 @@ public:
     Data<SReal> d_slideDistance ;
 //    Data<sofa::type::vector<double> > d_outputDist;
     sofa::component::constraint::lagrangian::solver::ConstraintSolverImpl* m_constraintSolver;
-    std::vector<TetrahedronElement::SPtr> m_tetras;
     std::vector<BaseProximity::SPtr> m_needlePts;
     std::vector<BaseProximity::SPtr> m_couplingPts;
 
@@ -50,7 +49,6 @@ public:
     , d_slideDistance(initData(&d_slideDistance, std::numeric_limits<double>::min(), "slideDistance", "Distance along the insertion trajectory after which the proximities slide backwards along the needle shaft"))
 //    , d_outputDist(initData(&d_outputDist,"outputDist", "Distance of the outpu pair of detections"))
     , m_constraintSolver(nullptr)
-    , m_tetras()
     , m_needlePts()
     , m_couplingPts()
     {}
@@ -75,16 +73,6 @@ public:
             vparams->drawTool()->drawSphere(it.first->getPosition(),  d_sphereRadius.getValue(), sofa::type::RGBAColor(1, 0, 0, 1));
             vparams->drawTool()->drawSphere(it.second->getPosition(), d_sphereRadius.getValue(), sofa::type::RGBAColor(0, 0, 1, 1));
             vparams->drawTool()->drawLine(it.first->getPosition(), it.second->getPosition(), sofa::type::RGBAColor(1, 1, 0, 1));
-        }
-
-        for(const auto& it : m_tetras) {
-            vparams->drawTool()->drawTetrahedron(
-                it->getP0()->getPosition(),
-                it->getP1()->getPosition(),
-                it->getP2()->getPosition(),
-                it->getP3()->getPosition(),
-                sofa::type::RGBAColor(1, 1, 0, 0.3)
-            );
         }
     }
 
@@ -165,20 +153,6 @@ public:
                 auto pdestVol = findClosestProxOp_vol(m_needlePts.back(), l_destVol.get(), projectOp_vol, getFilterFunc());
                 if (pdestVol != nullptr) 
                 {
-                    /*
-                    TetrahedronProximity::SPtr tetraProx = std::dynamic_pointer_cast<TetrahedronProximity>(pdestVol);
-                    double* baryCoords = tetraProx->getBaryCoord();
-                    if (toolbox::TetrahedronToolBox::isInTetra(
-                            pfrom->getPosition(),
-                            tetraProx->element()->getTetrahedronInfo(),
-                            baryCoords[0],
-                            baryCoords[1],
-                            baryCoords[2],
-                            baryCoords[3]
-                        )
-                    ) m_tetras.push_back(tetraProx->element());
-                    */
-
                     pdestVol->normalize();
                     m_couplingPts.push_back(pdestVol);
                     m_needlePts.push_back(m_needlePts.back());


### PR DESCRIPTION
## Additions
At the moment when the insertion begins, the algorithm now performs the following steps:
1. It stores the first point of insertion.
2. When the needle tip has travelled a specified distance inside the volume, another coupling point is added.
3. The previous coupling points slide backwards along the needle shaft.
4. The algorithm exports these coupling points at every time step.

https://github.com/user-attachments/assets/ac9e86f0-663e-422d-8b27-a461a83e5e09

## To Improve
1. ~~Currently, only one coupling point can be assigned to each segment of the needle beam. The `d_slideDistance` variable should match the length of each needle segment. This simplifies the backward sliding of coupling points, as there's no need to track how many segments have moved along the insertion path. But normally, this limitation should not be in place.~~ solved by [bc791a8](https://github.com/InfinyTech3D/CollisionAlgorithm/pull/24/commits/bc791a8a98b6bdb6cc277b07f2658d9ddbfdb7cc)
2. ~~When it is time to slide proximity pairs backwards, the proximities on the needle should be re-projected from the tetrahedron proximities back at the needle.~~ see #32 

Closes #18, closes #17