### PR TITLE
[Needle][algorithm] Reprojection of volume proximities on the needle

### DIFF
--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -158,13 +158,17 @@ public:
                     m_needlePts.push_back(m_needlePts.back());
 
                     auto itfromVol = l_fromVol->begin(l_fromVol->getSize() - 1 - m_couplingPts.size());
-                    auto createProximityOp_vol = Operations::CreateCenterProximity::Operation::get(itfromVol->getTypeInfo());
+                    //auto createProximityOp_vol = Operations::CreateCenterProximity::Operation::get(itfromVol->getTypeInfo());
+
+                    auto findClosestProxOp_needle = Operations::FindClosestProximity::Operation::get(l_fromVol);
+                    auto projectOp_needle = Operations::Project::Operation::get(l_fromVol);
 
                     for(int i = 0 ; i < m_needlePts.size() - 1; i++)
                     {
-                        auto pfromVol = createProximityOp_vol(itfromVol->element());
+                        //auto pfromVol = createProximityOp_vol(itfromVol->element());
+                        auto pfromVol = findClosestProxOp_needle(m_couplingPts[i], l_fromVol.get(), projectOp_needle, getFilterFunc());
                         if (d_projective.getValue()) {
-                            auto pfromVolProj = projectFromOp_vol(pdestVol->getPosition(), itfromVol->element()).prox;
+                            auto pfromVolProj = projectFromOp_vol(m_couplingPts[i]->getPosition(), itfromVol->element()).prox;
                             if (pfromVolProj == nullptr) continue;
                             pfromVolProj->normalize();
                             m_needlePts[i] = pfromVolProj;


### PR DESCRIPTION
# This PR is based on https://github.com/InfinyTech3D/CollisionAlgorithm/pull/21 which should be merged first.

## Modifications

This PR continues the work in #31. It modifies the insertion algorithm to re-project the already detected proximities back onto the needle. It solves the problem of always adding proximities in the middle of each edge of the needle beam.

## Issues Closed

Closes #25 