### PR TITLE
[Needle][algorithm] Volume proximities are re-projected back onto the needle at every time step

### DIFF
--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -146,20 +146,20 @@ public:
         }
         else
         {
+            outputList.clear();
+
             auto itfrom = l_from->begin();
             auto createProximityOp = Operations::CreateCenterProximity::Operation::get(itfrom->getTypeInfo());
             auto pfrom = createProximityOp(itfrom->element());
 
             const SReal dist = (pfrom->getPosition() - m_couplingPts.back()->getPosition()).norm();
-
-            outputList.clear();
             if(dist > d_slideDistance.getValue()) 
             {
                 auto findClosestProxOp_vol = Operations::FindClosestProximity::Operation::get(l_destVol);
                 auto projectOp_vol = Operations::Project::Operation::get(l_destVol);
                 auto projectFromOp_vol = Operations::Project::Operation::get(l_fromVol);
                 auto pdestVol = findClosestProxOp_vol(pfrom, l_destVol.get(), projectOp_vol, getFilterFunc());
-                if (pdestVol != nullptr)
+                if (pdestVol)
                 {
                     pdestVol->normalize();
                     m_couplingPts.push_back(pdestVol);
@@ -170,13 +170,13 @@ public:
             auto findClosestProxOp_needle = Operations::FindClosestProximity::Operation::get(l_fromVol);
             auto projectOp_needle = Operations::Project::Operation::get(l_fromVol);
 
-            for(int i = 0 ; i < m_needlePts.size(); i++)
+            for(int i = 0 ; i < m_couplingPts.size(); i++)
             {
                 auto pfromVol = findClosestProxOp_needle(m_couplingPts[i], l_fromVol.get(), projectOp_needle, getFilterFunc());
                 m_needlePts[i] = pfromVol;
             }
 
-            for(int i = 0 ; i < m_needlePts.size(); i++)
+            for(int i = 0 ; i < m_couplingPts.size(); i++)
                 outputList.add(m_needlePts[i], m_couplingPts[i]);
         }
 


### PR DESCRIPTION
## What's changed

The proximities do not slide along the needle shaft as it moves inside the volume. They stay as close as possible to the volume coupling points, as shown in the video:

https://github.com/user-attachments/assets/10a47586-919c-4b14-995a-014dead5610c

## Issues

Closes #34 

> [!NOTE]
> Seems like the projection happens one time step ahead than when it should be done. To improve in future PR if that's the case.