### PR TITLE
[algorithm] Refactor PR #5 - Remove needlePts variable

### DIFF
--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -198,7 +198,9 @@ class InsertionAlgorithm : public BaseAlgorithm
                                           .normalized();
             const type::Vec3 ab = m_couplingPts.back()->getPosition() - tipProx->getPosition();
             const SReal dotProd = dot(ab, normal);
-            if (dotProd > 0.0) m_couplingPts.pop_back();
+            if (dotProd > 0.0) {
+                m_couplingPts.pop_back();
+            }
 
             const SReal dist = ab.norm();
             if (dist > d_tipDistThreshold.getValue())


### PR DESCRIPTION
### Info & Merging
- A series of PRs to clean-up and simplify the algorithm, and make it easier to make additions in the future.
### Dependencies
- After PR #50 
### Changes
- The needlePts variable is not needed since the algorithm re-projects proximities on the needle shaft at every time step.