### PR TITLE
[algorithm] Refactor PR #6 - Rework order of removal/addition of coupling points

### DIFF
--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -188,8 +188,8 @@ class InsertionAlgorithm : public BaseAlgorithm
                 Operations::CreateCenterProximity::Operation::get(itTip->getTypeInfo());
             const BaseProximity::SPtr tipProx = createTipProximity(itTip->element());
 
-            const type::Vec3 ab = m_couplingPts.back()->getPosition() - tipProx->getPosition();
-            if (ab.norm() > d_tipDistThreshold.getValue())
+            const type::Vec3 tip2Pt = m_couplingPts.back()->getPosition() - tipProx->getPosition();
+            if (tip2Pt.norm() > d_tipDistThreshold.getValue())
             {
                 auto findClosestProxOnVol =
                     Operations::FindClosestProximity::Operation::get(l_volGeom);
@@ -212,8 +212,7 @@ class InsertionAlgorithm : public BaseAlgorithm
                 const type::Vec3 normal = (edgeProx->element()->getP1()->getPosition() -
                                            edgeProx->element()->getP0()->getPosition())
                                               .normalized();
-                const SReal dotProd = dot(ab, normal);
-                if (dotProd > 0.0) {
+                if (dot(tip2Pt, normal) > 0_sreal) {
                     m_couplingPts.pop_back();
                 }
             }

--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -188,22 +188,8 @@ class InsertionAlgorithm : public BaseAlgorithm
                 Operations::CreateCenterProximity::Operation::get(itTip->getTypeInfo());
             const BaseProximity::SPtr tipProx = createTipProximity(itTip->element());
 
-            ElementIterator::SPtr itShaft = l_shaftGeom->begin(l_shaftGeom->getSize() - 2);
-            auto createShaftProximity =
-                Operations::CreateCenterProximity::Operation::get(itShaft->getTypeInfo());
-            const BaseProximity::SPtr shaftProx = createShaftProximity(itShaft->element());
-            const EdgeProximity::SPtr edgeProx = dynamic_pointer_cast<EdgeProximity>(shaftProx);
-            const type::Vec3 normal = (edgeProx->element()->getP1()->getPosition() -
-                                       edgeProx->element()->getP0()->getPosition())
-                                          .normalized();
             const type::Vec3 ab = m_couplingPts.back()->getPosition() - tipProx->getPosition();
-            const SReal dotProd = dot(ab, normal);
-            if (dotProd > 0.0) {
-                m_couplingPts.pop_back();
-            }
-
-            const SReal dist = ab.norm();
-            if (dist > d_tipDistThreshold.getValue())
+            if (ab.norm() > d_tipDistThreshold.getValue())
             {
                 auto findClosestProxOnVol =
                     Operations::FindClosestProximity::Operation::get(l_volGeom);
@@ -214,6 +200,21 @@ class InsertionAlgorithm : public BaseAlgorithm
                 {
                     volProx->normalize();
                     m_couplingPts.push_back(volProx);
+                }
+            }
+            else // Don't bother with removing the point that was just added
+            {
+                ElementIterator::SPtr itShaft = l_shaftGeom->begin(l_shaftGeom->getSize() - 2);
+                auto createShaftProximity =
+                    Operations::CreateCenterProximity::Operation::get(itShaft->getTypeInfo());
+                const BaseProximity::SPtr shaftProx = createShaftProximity(itShaft->element());
+                const EdgeProximity::SPtr edgeProx = dynamic_pointer_cast<EdgeProximity>(shaftProx);
+                const type::Vec3 normal = (edgeProx->element()->getP1()->getPosition() -
+                                           edgeProx->element()->getP0()->getPosition())
+                                              .normalized();
+                const SReal dotProd = dot(ab, normal);
+                if (dotProd > 0.0) {
+                    m_couplingPts.pop_back();
                 }
             }
 


### PR DESCRIPTION
### Info & Merging
- A series of PRs to clean-up and simplify the algorithm, and make it easier to make additions in the future.
- Suggest to squash-merge each PR into the dev-refactor branch and then rebase-merge that into the master branch.
### Dependencies
- After PR #51 
### Changes
- The removal and addition of coupling points should be exclusive with respect to one another (within the same time step). With this PR, we first check whether a coupling point should be added and, only in case it does not, we check whether it should be removed. This avoids an inconsistent scenario where a point could both be added and removed as the two checks could be true at the same time.