### PR TITLE
[algorithm] Refactor PR #7 - More consistent check to initiate the puncture

### DIFF
--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -153,7 +153,7 @@ class InsertionAlgorithm : public BaseAlgorithm
                             l_tipGeom->getContext()->get<MechStateTipType>();
                         const auto& lambda =
                             m_constraintSolver->getLambda()[mstate.get()].read()->getValue();
-                        SReal norm{0.};
+                        SReal norm{0_sreal};
                         for (const auto& l : lambda) {
                             norm += l.norm();
                         }


### PR DESCRIPTION
### Info & Merging
- A series of PRs to clean-up and simplify the algorithm, and make it easier to make additions in the future.
### Dependencies
- After PR #52 
### Changes
- Changed the order of operations during the puncture phase. Before checking whether the `punctureThreshold` is surpassed, a new surface proximity is first detected. This new proximity should be used to couple the needle and not the one determined in the previous step. This approach should be more consistent because the animation loop has already displaced the needle as if there was a collision with the surface before the `doDetection()` function was called again.
- The re-projection of coupling points on the needle now takes place at the end of doDetection(), accounting for any previous modification to the list of coupling points.