### PR TITLE
[filters] Correction in register of DistanceFilter class

### DIFF
--- a/src/sofa/collisionAlgorithm/filters/DistanceFilter.h
+++ b/src/sofa/collisionAlgorithm/filters/DistanceFilter.h
@@ -10,7 +10,7 @@ namespace sofa::collisionAlgorithm {
  */
 class DistanceFilter : public BaseAlgorithm::BaseFilter {
 public:
-    SOFA_ABSTRACT_CLASS(BaseFilter, BaseFilter);
+    SOFA_CLASS(DistanceFilter, BaseFilter);
 
     Data<double> d_distance;
 


### PR DESCRIPTION
1. Changed macro to declare this class - it is not an abstract interface class.
2. Registered it appropriately - suppresses spurious warning from SOFA about using `DistanceFilter` "alias" in the scene.