### PR TITLE
[algorithm] Add proper check to enable or disable collision with the needle shaft

### DIFF
--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -178,7 +178,7 @@ class InsertionAlgorithm : public BaseAlgorithm
             }
 
             // 1.3 Collision with the shaft geometry
-            if (collisionOutput.size())
+            if (m_couplingPts.empty())
             {
                 auto createShaftProximity =
                     Operations::CreateCenterProximity::Operation::get(l_shaftGeom->getTypeInfo());


### PR DESCRIPTION
This is to fix #78

It is better to use `m_couplingPts` to indicate whether insertion has started and disable or enable collision between the needle shaft and the surface of interest.


https://github.com/user-attachments/assets/a994190a-65be-4de7-997c-6c2be6294434

