### PR TITLE
[algorithm] Fix problem with gap in coupling points when puncturing tissue with high stiffness

### DIFF
--- a/scenes/NeedleInsertion.py
+++ b/scenes/NeedleInsertion.py
@@ -190,7 +190,7 @@ def createScene(root):
         shaftGeom="@Needle/bodyCollision/geom_body", 
         volGeom="@Volume/geom_tetra", 
         punctureForceThreshold=20, 
-        tipDistThreshold=0.003,
+        tipDistThreshold=0.005,
         drawcollision=True,
         drawPointsScale=0.0001
     )

--- a/scenes/NeedleInsertion.py
+++ b/scenes/NeedleInsertion.py
@@ -60,7 +60,7 @@ def createScene(root):
     root.addObject("ConstraintAttachButtonSetting")
     root.addObject("VisualStyle", displayFlags="showVisualModels hideBehaviorModels showCollisionModels hideMappings hideForceFields showWireframe showInteractionForceFields" )
     root.addObject("FreeMotionAnimationLoop")
-    root.addObject("GenericConstraintSolver", tolerance=1e-3, maxIt=5000)
+    root.addObject("GenericConstraintSolver", tolerance=1e-5, maxIt=5000)
     root.addObject("CollisionLoop")
 
     needleBaseMaster = root.addChild("NeedleBaseMaster")
@@ -199,4 +199,4 @@ def createScene(root):
     root.addObject("ConstraintUnilateral",input="@InsertionAlgo.collisionOutput",directions="@punctureDirection",draw_scale=0.001)
 
     root.addObject("FirstDirection",name="bindDirection", handler="@Needle/bodyCollision/NeedleBeams")
-    root.addObject("ConstraintInsertion",input="@InsertionAlgo.insertionOutput", directions="@bindDirection",draw_scale=0.002, frictionCoeff=0.05)
+    root.addObject("ConstraintInsertion",input="@InsertionAlgo.insertionOutput", directions="@bindDirection",draw_scale=0.002, frictionCoeff=0.01)

--- a/scenes/NeedleInsertion.py
+++ b/scenes/NeedleInsertion.py
@@ -190,7 +190,7 @@ def createScene(root):
         shaftGeom="@Needle/bodyCollision/geom_body", 
         volGeom="@Volume/geom_tetra", 
         punctureForceThreshold=20, 
-        tipDistThreshold=0.005,
+        tipDistThreshold=0.003,
         drawcollision=True,
         drawPointsScale=0.0001
     )

--- a/scenes/NeedleInsertion.py
+++ b/scenes/NeedleInsertion.py
@@ -6,7 +6,7 @@ g_needleBaseOffset=[0.04,0.04,0]
 g_needleRadius = 0.001 #(m)
 g_needleMechanicalParameters = {
     "radius":g_needleRadius,
-    "youngModulus":1e11,
+    "youngModulus":1e12,
     "poissonRatio":0.3
 }
 g_needleTotalMass=0.01
@@ -17,7 +17,7 @@ g_gelRegularGridParameters = {
     "max":[0.125, 0.125, -0.100]
 } #Again all in mm
 g_gelMechanicalParameters = {
-    "youngModulus":8e5,
+    "youngModulus":1e6,
     "poissonRatio":0.45,
     "method":"large"
 }
@@ -60,7 +60,7 @@ def createScene(root):
     root.addObject("ConstraintAttachButtonSetting")
     root.addObject("VisualStyle", displayFlags="showVisualModels hideBehaviorModels showCollisionModels hideMappings hideForceFields showWireframe showInteractionForceFields" )
     root.addObject("FreeMotionAnimationLoop")
-    root.addObject("GenericConstraintSolver", tolerance=0.00001, maxIt=5000)
+    root.addObject("GenericConstraintSolver", tolerance=1e-3, maxIt=5000)
     root.addObject("CollisionLoop")
 
     needleBaseMaster = root.addChild("NeedleBaseMaster")
@@ -189,7 +189,7 @@ def createScene(root):
         surfGeom="@Volume/collision/geom_tri", 
         shaftGeom="@Needle/bodyCollision/geom_body", 
         volGeom="@Volume/geom_tetra", 
-        punctureForceThreshold=2., 
+        punctureForceThreshold=20, 
         tipDistThreshold=0.003,
         drawcollision=True,
         drawPointsScale=0.0001

--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -287,45 +287,6 @@ class InsertionAlgorithm : public BaseAlgorithm
                     }
                 }
             }
-
-            // ElementIterator::SPtr itTip = l_tipGeom->begin();
-            // auto createTipProximity =
-            //   Operations::CreateCenterProximity::Operation::get(itTip->getTypeInfo());
-            // const BaseProximity::SPtr tipProx = createTipProximity(itTip->element());
-            // if (!tipProx) return;
-            //
-            //// 2.1 Check whether coupling point should be added
-            // const type::Vec3 tipToLastCP = m_CPs.back()->getPosition() - tipProx->getPosition();
-            // if (tipToLastCP.norm() > d_tipDistThreshold.getValue())
-            //{
-            //     auto findClosestProxOnVol =
-            //         Operations::FindClosestProximity::Operation::get(l_volGeom);
-            //     auto projectOnVol = Operations::Project::Operation::get(l_volGeom);
-            //     const BaseProximity::SPtr volProx =
-            //         findClosestProxOnVol(tipProx, l_volGeom.get(), projectOnVol,
-            //         getFilterFunc());
-            //     // Proximity can be detected before the tip enters the tetra (e.g. near a
-            //     boundary
-            //     // face) Only accept proximities if the tip is inside the tetra during insertion
-            //     if (volProx)
-            //     {
-            //         TetrahedronProximity::SPtr tetProx =
-            //             dynamic_pointer_cast<TetrahedronProximity>(volProx);
-            //         if (tetProx)
-            //         {
-            //             double f0(tetProx->f0()), f1(tetProx->f1()), f2(tetProx->f2()),
-            //                 f3(tetProx->f3());
-            //             bool isInTetra = toolbox::TetrahedronToolBox::isInTetra(
-            //                 tipProx->getPosition(), tetProx->element()->getTetrahedronInfo(), f0,
-            //                 f1, f2, f3);
-            //             if (isInTetra)
-            //             {
-            //                 volProx->normalize();
-            //                 m_CPs.push_back(volProx);
-            //             }
-            //         }
-            //     }
-            // }
             else  // Don't bother with removing the point that was just added
             {
                 // 2.2. Check whether coupling point should be removed

--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -218,8 +218,8 @@ class InsertionAlgorithm : public BaseAlgorithm
             // 2.1 Check whether coupling point should be added
             type::Vec3 lastCouplingPt = m_couplingPts.back()->getPosition();
             const SReal tipDistThreshold = this->d_tipDistThreshold.getValue();
-            const type::Vec3 tip2Pt = lastCouplingPt - tipProx->getPosition();
-            if (tip2Pt.norm() > tipDistThreshold)
+            const type::Vec3 tipToLastCouplingPt = lastCouplingPt - tipProx->getPosition();
+            if (tipToLastCouplingPt.norm() > tipDistThreshold)
             {
                 // find our current segment:
                 auto createShaftProximity =
@@ -240,7 +240,7 @@ class InsertionAlgorithm : public BaseAlgorithm
                             const type::Vec3 p0 = edgeProx->element()->getP0()->getPosition();
                             const type::Vec3 p1 = edgeProx->element()->getP1()->getPosition();
                             const type::Vec3 newCp = lastCouplingPt + tipDistThreshold * (p1 - lastCouplingPt).normalized();
-                            if(dot(tip2Pt, (newCp - lastCouplingPt)) > 0_sreal) continue;
+                            if(dot(tipToLastCouplingPt, (newCp - lastCouplingPt)) > 0_sreal) continue;
                             const type::Vec3 edgeNormal = (p1 - p0).normalized();
                             const SReal edgeSegmentLength = (p1 - p0).norm();
                             const type::Vec3 p0toCp = newCp - p0;
@@ -282,8 +282,8 @@ class InsertionAlgorithm : public BaseAlgorithm
             //if (!tipProx) return;
             //
             //// 2.1 Check whether coupling point should be added
-            //const type::Vec3 tip2Pt = m_couplingPts.back()->getPosition() - tipProx->getPosition();
-            //if (tip2Pt.norm() > d_tipDistThreshold.getValue())
+            //const type::Vec3 tipToLastCouplingPt = m_couplingPts.back()->getPosition() - tipProx->getPosition();
+            //if (tipToLastCouplingPt.norm() > d_tipDistThreshold.getValue())
             //{
             //    auto findClosestProxOnVol =
             //        Operations::FindClosestProximity::Operation::get(l_volGeom);
@@ -329,7 +329,7 @@ class InsertionAlgorithm : public BaseAlgorithm
                                                       .normalized();
                         // If the (last) coupling point lies ahead of the tip (positive dot
                         // product), the needle is retreating. Thus, that point is removed.
-                        if (dot(tip2Pt, normal) > 0_sreal)
+                        if (dot(tipToLastCouplingPt, normal) > 0_sreal)
                         {
                             m_couplingPts.pop_back();
                         }

--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -241,10 +241,10 @@ class InsertionAlgorithm : public BaseAlgorithm
                             const type::Vec3 p1 = edgeProx->element()->getP1()->getPosition();
                             const type::Vec3 candidateCP = lastCP + tipDistThreshold * (p1 - lastCP).normalized();
                             if(dot(tipToLastCP, (candidateCP - lastCP)) > 0_sreal) continue;
-                            const type::Vec3 edgeNormal = (p1 - p0).normalized();
+                            const type::Vec3 shaftEdgeDirection = (p1 - p0).normalized();
                             const SReal edgeSegmentLength = (p1 - p0).norm();
                             const type::Vec3 p0ToCandidateCP = candidateCP - p0;
-                            const SReal dotProd = dot(edgeNormal, p0ToCandidateCP);
+                            const SReal dotProd = dot(shaftEdgeDirection, p0ToCandidateCP);
                             if (dotProd < 0_sreal || dotProd > edgeSegmentLength) continue;
     
                             shaftProx = projectOnShaft(candidateCP, itShaft->element()).prox;

--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -243,8 +243,8 @@ class InsertionAlgorithm : public BaseAlgorithm
                             if(dot(tipToLastCouplingPt, (candidateCouplingPt - lastCouplingPt)) > 0_sreal) continue;
                             const type::Vec3 edgeNormal = (p1 - p0).normalized();
                             const SReal edgeSegmentLength = (p1 - p0).norm();
-                            const type::Vec3 p0toCp = candidateCouplingPt - p0;
-                            const SReal dotProd = dot(edgeNormal, p0toCp);
+                            const type::Vec3 p0ToCandidatePt = candidateCouplingPt - p0;
+                            const SReal dotProd = dot(edgeNormal, p0ToCandidatePt);
                             if (dotProd < 0_sreal || dotProd > edgeSegmentLength) continue;
     
                             shaftProx = projectOnShaft(candidateCouplingPt, itShaft->element()).prox;

--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -241,11 +241,11 @@ class InsertionAlgorithm : public BaseAlgorithm
                             const type::Vec3 p1 = edgeProx->element()->getP1()->getPosition();
                             const type::Vec3 candidateCP = lastCP + tipDistThreshold * (p1 - lastCP).normalized();
                             if(dot(tipToLastCP, (candidateCP - lastCP)) > 0_sreal) continue;
-                            const type::Vec3 shaftEdgeDirection = (p1 - p0).normalized();
+                            const type::Vec3 shaftEdgeDir = (p1 - p0).normalized();
                             const SReal edgeSegmentLength = (p1 - p0).norm();
                             const type::Vec3 p0ToCandidateCP = candidateCP - p0;
-                            const SReal dotProd = dot(shaftEdgeDirection, p0ToCandidateCP);
-                            if (dotProd < 0_sreal || dotProd > edgeSegmentLength) continue;
+                            const SReal projPtOnEdge = dot(p0ToCandidateCP, shaftEdgeDir);
+                            if (projPtOnEdge < 0_sreal || projPtOnEdge > edgeSegmentLength) continue;
     
                             shaftProx = projectOnShaft(candidateCP, itShaft->element()).prox;
                             const BaseProximity::SPtr volProx =

--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -239,15 +239,15 @@ class InsertionAlgorithm : public BaseAlgorithm
                         {
                             const type::Vec3 p0 = edgeProx->element()->getP0()->getPosition();
                             const type::Vec3 p1 = edgeProx->element()->getP1()->getPosition();
-                            const type::Vec3 newCp = lastCouplingPt + tipDistThreshold * (p1 - lastCouplingPt).normalized();
-                            if(dot(tipToLastCouplingPt, (newCp - lastCouplingPt)) > 0_sreal) continue;
+                            const type::Vec3 candidateCouplingPt = lastCouplingPt + tipDistThreshold * (p1 - lastCouplingPt).normalized();
+                            if(dot(tipToLastCouplingPt, (candidateCouplingPt - lastCouplingPt)) > 0_sreal) continue;
                             const type::Vec3 edgeNormal = (p1 - p0).normalized();
                             const SReal edgeSegmentLength = (p1 - p0).norm();
-                            const type::Vec3 p0toCp = newCp - p0;
+                            const type::Vec3 p0toCp = candidateCouplingPt - p0;
                             const SReal dotProd = dot(edgeNormal, p0toCp);
                             if (dotProd < 0_sreal || dotProd > edgeSegmentLength) continue;
     
-                            shaftProx = projectOnShaft(newCp, itShaft->element()).prox;
+                            shaftProx = projectOnShaft(candidateCouplingPt, itShaft->element()).prox;
                             const BaseProximity::SPtr volProx =
                                 findClosestProxOnVol(shaftProx, l_volGeom.get(), projectOnVol, getFilterFunc());
                             if (volProx)

--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -216,10 +216,10 @@ class InsertionAlgorithm : public BaseAlgorithm
             if (!tipProx) return;
 
             // 2.1 Check whether coupling point should be added
-            type::Vec3 lastCouplingPt = m_couplingPts.back()->getPosition();
+            type::Vec3 lastCP = m_couplingPts.back()->getPosition();
             const SReal tipDistThreshold = this->d_tipDistThreshold.getValue();
-            const type::Vec3 tipToLastCouplingPt = lastCouplingPt - tipProx->getPosition();
-            if (tipToLastCouplingPt.norm() > tipDistThreshold)
+            const type::Vec3 tipToLastCP = lastCP - tipProx->getPosition();
+            if (tipToLastCP.norm() > tipDistThreshold)
             {
                 // find our current segment:
                 auto createShaftProximity =
@@ -239,15 +239,15 @@ class InsertionAlgorithm : public BaseAlgorithm
                         {
                             const type::Vec3 p0 = edgeProx->element()->getP0()->getPosition();
                             const type::Vec3 p1 = edgeProx->element()->getP1()->getPosition();
-                            const type::Vec3 candidateCouplingPt = lastCouplingPt + tipDistThreshold * (p1 - lastCouplingPt).normalized();
-                            if(dot(tipToLastCouplingPt, (candidateCouplingPt - lastCouplingPt)) > 0_sreal) continue;
+                            const type::Vec3 candidateCP = lastCP + tipDistThreshold * (p1 - lastCP).normalized();
+                            if(dot(tipToLastCP, (candidateCP - lastCP)) > 0_sreal) continue;
                             const type::Vec3 edgeNormal = (p1 - p0).normalized();
                             const SReal edgeSegmentLength = (p1 - p0).norm();
-                            const type::Vec3 p0ToCandidatePt = candidateCouplingPt - p0;
-                            const SReal dotProd = dot(edgeNormal, p0ToCandidatePt);
+                            const type::Vec3 p0ToCandidateCP = candidateCP - p0;
+                            const SReal dotProd = dot(edgeNormal, p0ToCandidateCP);
                             if (dotProd < 0_sreal || dotProd > edgeSegmentLength) continue;
     
-                            shaftProx = projectOnShaft(candidateCouplingPt, itShaft->element()).prox;
+                            shaftProx = projectOnShaft(candidateCP, itShaft->element()).prox;
                             const BaseProximity::SPtr volProx =
                                 findClosestProxOnVol(shaftProx, l_volGeom.get(), projectOnVol, getFilterFunc());
                             if (volProx)
@@ -265,7 +265,7 @@ class InsertionAlgorithm : public BaseAlgorithm
                                     {
                                         volProx->normalize();
                                         m_couplingPts.push_back(volProx);
-                                        lastCouplingPt = volProx->getPosition();
+                                        lastCP = volProx->getPosition();
                                     }
                                 }
                             }
@@ -282,8 +282,8 @@ class InsertionAlgorithm : public BaseAlgorithm
             //if (!tipProx) return;
             //
             //// 2.1 Check whether coupling point should be added
-            //const type::Vec3 tipToLastCouplingPt = m_couplingPts.back()->getPosition() - tipProx->getPosition();
-            //if (tipToLastCouplingPt.norm() > d_tipDistThreshold.getValue())
+            //const type::Vec3 tipToLastCP = m_couplingPts.back()->getPosition() - tipProx->getPosition();
+            //if (tipToLastCP.norm() > d_tipDistThreshold.getValue())
             //{
             //    auto findClosestProxOnVol =
             //        Operations::FindClosestProximity::Operation::get(l_volGeom);
@@ -329,7 +329,7 @@ class InsertionAlgorithm : public BaseAlgorithm
                                                       .normalized();
                         // If the (last) coupling point lies ahead of the tip (positive dot
                         // product), the needle is retreating. Thus, that point is removed.
-                        if (dot(tipToLastCouplingPt, normal) > 0_sreal)
+                        if (dot(tipToLastCP, normal) > 0_sreal)
                         {
                             m_couplingPts.pop_back();
                         }

--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -216,9 +216,9 @@ class InsertionAlgorithm : public BaseAlgorithm
             if (!tipProx) return;
 
             // 2.1 Check whether coupling point should be added
-            type::Vec3 lastCp = m_couplingPts.back()->getPosition();
+            type::Vec3 lastCouplingPt = m_couplingPts.back()->getPosition();
             const SReal tipDistThreshold = this->d_tipDistThreshold.getValue();
-            const type::Vec3 tip2Pt = lastCp - tipProx->getPosition();
+            const type::Vec3 tip2Pt = lastCouplingPt - tipProx->getPosition();
             if (tip2Pt.norm() > tipDistThreshold)
             {
                 // find our current segment:
@@ -239,8 +239,8 @@ class InsertionAlgorithm : public BaseAlgorithm
                         {
                             const type::Vec3 p0 = edgeProx->element()->getP0()->getPosition();
                             const type::Vec3 p1 = edgeProx->element()->getP1()->getPosition();
-                            const type::Vec3 newCp = lastCp + tipDistThreshold * (p1 - lastCp).normalized();
-                            if(dot(tip2Pt, (newCp - lastCp)) > 0_sreal) continue;
+                            const type::Vec3 newCp = lastCouplingPt + tipDistThreshold * (p1 - lastCouplingPt).normalized();
+                            if(dot(tip2Pt, (newCp - lastCouplingPt)) > 0_sreal) continue;
                             const type::Vec3 edgeNormal = (p1 - p0).normalized();
                             const SReal edgeSegmentLength = (p1 - p0).norm();
                             const type::Vec3 p0toCp = newCp - p0;
@@ -265,7 +265,7 @@ class InsertionAlgorithm : public BaseAlgorithm
                                     {
                                         volProx->normalize();
                                         m_couplingPts.push_back(volProx);
-                                        lastCp = volProx->getPosition();
+                                        lastCouplingPt = volProx->getPosition();
                                     }
                                 }
                             }

--- a/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
+++ b/src/sofa/collisionAlgorithm/algorithm/InsertionAlgorithm.h
@@ -243,17 +243,17 @@ class InsertionAlgorithm : public BaseAlgorithm
 
                     const type::Vec3 p0 = edgeProx->element()->getP0()->getPosition();
                     const type::Vec3 p1 = edgeProx->element()->getP1()->getPosition();
+                    const type::Vec3 shaftEdgeDir = (p1 - p0).normalized();
+                    const type::Vec3 lastCPToP1 = p1 - lastCP;
+
+                    // Skip if last CP lies after edge end point
+                    if (dot(shaftEdgeDir, lastCPToP1) < 0_sreal) continue;
 
                     // Candidate coupling point along shaft segment
-                    const type::Vec3 candidateCP =
-                        lastCP + tipDistThreshold * (p1 - lastCP).normalized();
-
-                    // Skip if candidate CP lies before the last CP
-                    if (dot(tipToLastCP, (candidateCP - lastCP)) > 0_sreal) continue;
+                    const type::Vec3 candidateCP = lastCP + tipDistThreshold * shaftEdgeDir;
 
                     // Project candidate CP onto the edge element and compute scalar coordinate
                     // along segment
-                    const type::Vec3 shaftEdgeDir = (p1 - p0).normalized();
                     const SReal edgeSegmentLength = (p1 - p0).norm();
                     const type::Vec3 p0ToCandidateCP = candidateCP - p0;
                     const SReal projPtOnEdge = dot(p0ToCandidateCP, shaftEdgeDir);


### PR DESCRIPTION
The problem is described in issue #80 along with a video.

The solution is to change the proximity detection and coupling point addition algorithm. Instead of relying on the tip to detect tetrahedral proximities, the modified algorithm starts from the last coupling point added and traverses the needle edge segments until it reaches the tip while adding evenly spaced coupling points along the way. This avoids creating a gap after puncturing the surface.

https://github.com/user-attachments/assets/933854ad-1685-45a6-a372-0888223a88de

Fix #80 