### PR TITLE
[collision] Remove API export for proximity classes

### DIFF
--- a/src/CollisionAlgorithm/proximity/EdgeProximity.h
+++ b/src/CollisionAlgorithm/proximity/EdgeProximity.h
@@ -6,7 +6,7 @@
 
 namespace sofa::collisionalgorithm {
 
-class SOFA_COLLISIONALGORITHM_API EdgeProximity : public BaseProximity {
+class EdgeProximity : public BaseProximity {
 public:
 
     typedef std::shared_ptr<EdgeProximity> SPtr;

--- a/src/CollisionAlgorithm/proximity/FixedProximity.h
+++ b/src/CollisionAlgorithm/proximity/FixedProximity.h
@@ -5,7 +5,7 @@
 
 namespace sofa::collisionalgorithm {
 
-class SOFA_COLLISIONALGORITHM_API FixedProximity : public BaseProximity{
+class FixedProximity : public BaseProximity{
 public:
   typedef std::shared_ptr<FixedProximity> SPtr;
   typedef typename collisionalgorithm::BaseProximity Inherits;

--- a/src/CollisionAlgorithm/proximity/MultiProximity.h
+++ b/src/CollisionAlgorithm/proximity/MultiProximity.h
@@ -5,7 +5,7 @@
 
 namespace sofa::collisionalgorithm {
 
-class SOFA_COLLISIONALGORITHM_API MultiProximity : public BaseProximity {
+class MultiProximity : public BaseProximity {
 public:
 
     typedef std::shared_ptr<MultiProximity> SPtr;

--- a/src/CollisionAlgorithm/proximity/PointProximity.h
+++ b/src/CollisionAlgorithm/proximity/PointProximity.h
@@ -5,7 +5,7 @@
 
 namespace sofa::collisionalgorithm {
 
-class SOFA_COLLISIONALGORITHM_API PointProximity : public BaseProximity {
+class PointProximity : public BaseProximity {
 public:
 
     typedef std::shared_ptr<PointProximity> SPtr;

--- a/src/CollisionAlgorithm/proximity/TetrahedronProximity.h
+++ b/src/CollisionAlgorithm/proximity/TetrahedronProximity.h
@@ -7,7 +7,7 @@
 
 namespace sofa::collisionalgorithm {
 
-class SOFA_COLLISIONALGORITHM_API TetrahedronProximity : public BaseProximity {
+class TetrahedronProximity : public BaseProximity {
 public:
 
     typedef std::shared_ptr<TetrahedronProximity> SPtr;

--- a/src/CollisionAlgorithm/proximity/TriangleProximity.h
+++ b/src/CollisionAlgorithm/proximity/TriangleProximity.h
@@ -7,7 +7,7 @@
 
 namespace sofa::collisionalgorithm {
 
-class SOFA_COLLISIONALGORITHM_API TriangleProximity : public BaseProximity {
+class TriangleProximity : public BaseProximity {
 public:
 
     typedef std::shared_ptr<TriangleProximity> SPtr;


### PR DESCRIPTION
They're header only and confused MSVC in the new work