### PR TITLE
[operations] Robustify retraction detection check using tip velocity

### DIFF
--- a/src/CollisionAlgorithm/operations/NeedleOperations.cpp
+++ b/src/CollisionAlgorithm/operations/NeedleOperations.cpp
@@ -3,9 +3,6 @@
 namespace sofa::collisionalgorithm::Operations::Needle
 {
 
-// Returns true when at least one coupling point was popped from the back,
-// false when the set was left unchanged (including the null-edge error path
-// and the non-retracting early-exit).
 bool prunePointsUsingEdges(std::vector<BaseProximity::SPtr>& couplingPts,
                            const EdgeElement::SPtr& edge)
 {
@@ -38,6 +35,6 @@ bool prunePointsUsingEdges(std::vector<BaseProximity::SPtr>& couplingPts,
     return (couplingPts.size() < initSize);
 }
 
-int register_PrunePointsAheadOfTip_Edge =
-    PrunePointsAheadOfTip::register_func<EdgeElement>(&prunePointsUsingEdges);
+int register_PrunePointsAheadOfTip_Edge = PrunePointsAheadOfTip::register_func<EdgeElement>(&prunePointsUsingEdges);
+
 }  // namespace sofa::collisionalgorithm::Operations::Needle

--- a/src/CollisionAlgorithm/operations/NeedleOperations.cpp
+++ b/src/CollisionAlgorithm/operations/NeedleOperations.cpp
@@ -3,6 +3,9 @@
 namespace sofa::collisionalgorithm::Operations::Needle
 {
 
+// Returns true when at least one coupling point was popped from the back,
+// false when the set was left unchanged (including the null-edge error path
+// and the non-retracting early-exit).
 bool prunePointsUsingEdges(std::vector<BaseProximity::SPtr>& couplingPts,
                            const EdgeElement::SPtr& edge)
 {
@@ -16,11 +19,11 @@ bool prunePointsUsingEdges(std::vector<BaseProximity::SPtr>& couplingPts,
     const type::Vec3 tip(edge->getP1()->getPosition());
     const type::Vec3 edgeDirection = tip - edgeBase;
 
-    // Only prune if the tip is retracting (moving against the insertion direction). 
-    // NOTE: This uses the needle tip velocity only. If retraction results from needle-tissue 
+    // Only prune if the tip is retracting (moving against the insertion direction).
+    // NOTE: This uses the needle tip velocity only. If retraction results from needle-tissue
     //       relative movement, retraction is not detected.
     const type::Vec3 tipVelocity = edge->getP1()->getVelocity();
-    if (dot(tipVelocity, edgeDirection) >= 0_sreal) return true;
+    if (dot(tipVelocity, edgeDirection) >= 0_sreal) return false;
 
     const int initSize = couplingPts.size();
 
@@ -32,7 +35,7 @@ bool prunePointsUsingEdges(std::vector<BaseProximity::SPtr>& couplingPts,
         if(dot(tip2Pt, edgeDirection) < 0_sreal) break;
         couplingPts.pop_back();
     }
-    return (initSize == couplingPts.size());
+    return (couplingPts.size() < initSize);
 }
 
 int register_PrunePointsAheadOfTip_Edge =

--- a/src/CollisionAlgorithm/operations/NeedleOperations.cpp
+++ b/src/CollisionAlgorithm/operations/NeedleOperations.cpp
@@ -6,7 +6,7 @@ namespace sofa::collisionalgorithm::Operations::Needle
 bool prunePointsUsingEdges(std::vector<BaseProximity::SPtr>& couplingPts,
                            const EdgeElement::SPtr& edge)
 {
-    if (!edge) 
+    if (!edge)
     {
         msg_warning("Needle::PrunePointsAheadOfTip")
             << "Null element pointer in prunePointsUsingEdges; returning false";
@@ -15,6 +15,12 @@ bool prunePointsUsingEdges(std::vector<BaseProximity::SPtr>& couplingPts,
     const type::Vec3 edgeBase(edge->getP0()->getPosition());
     const type::Vec3 tip(edge->getP1()->getPosition());
     const type::Vec3 edgeDirection = tip - edgeBase;
+
+    // Only prune if the tip is retracting (moving against the insertion direction). 
+    // NOTE: This uses the needle tip velocity only. If retraction results from needle-tissue 
+    //       relative movement, retraction is not detected.
+    const type::Vec3 tipVelocity = edge->getP1()->getVelocity();
+    if (dot(tipVelocity, edgeDirection) >= 0_sreal) return true;
 
     const int initSize = couplingPts.size();
 

--- a/src/CollisionAlgorithm/operations/NeedleOperations.h
+++ b/src/CollisionAlgorithm/operations/NeedleOperations.h
@@ -29,6 +29,11 @@ class SOFA_COLLISIONALGORITHM_API PrunePointsAheadOfTip
     }
 };
 
+/**
+* Returns true when at least one coupling point was popped from the back, 
+* false when the set was left unchanged (including the null-edge error path
+* and the non-retracting early-exit).
+*/
 bool prunePointsUsingEdges(std::vector<BaseProximity::SPtr>& couplingPts,
                            const EdgeElement::SPtr& edgeProx);
 


### PR DESCRIPTION
This PR is about improving the retraction of the needle, during which coupling points have to be pruned ahead of the tip. 

We do a simple geometric test and prune them in case they are ahead. The proper thing to do would be to also account for the velocity of the tip. If it's moving backwards, we prune, otherwise we still keep the coupling points. 

On its own, this changes nothing. It only becomes relevant when a `contactDistance` parameter is introduced. With `contactDistance` and without this change, the coupling point would instantly get pruned at the point of puncture. 

The check is incremental